### PR TITLE
Implement Thread pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,16 @@ $ make bundle.install
 $ make sample.server
 ```
 
+## Using Thread Pool
+
+```ruby
+require './lib/adelnor/server'
+
+app = -> (env) do
+  [200, { 'Content-Type' => 'text/html' }, 'Hello world!']
+end
+
+Adelnor::Server.run app, 3000, thread_pool: 5
+```
+
 Open `http://localhost:3000`

--- a/lib/adelnor/request.rb
+++ b/lib/adelnor/request.rb
@@ -21,6 +21,8 @@ module Adelnor
       lines    = @message.split(/\r\n/)
       headline = lines.shift
 
+      return self unless headline
+
       parse_headline!(headline)
       parse_headers!(lines)
 

--- a/sample-app/run
+++ b/sample-app/run
@@ -4,7 +4,8 @@
 require './lib/adelnor/server'
 
 app = -> (env) do
+  sleep rand(0.01..1)
   [200, { 'Content-Type' => 'text/html' }, 'Hello world!']
 end
 
-Adelnor::Server.run app, 3000
+Adelnor::Server.run app, 3000, thread_pool: 5


### PR DESCRIPTION
We should be able to handle concurrency in Adelnor. By using a thread pool, requests can be assigned to one thread and be executed simultaneously.

Usage:
```ruby
require './lib/adelnor/server'

app = -> (env) do
  [200, { 'Content-Type' => 'text/html' }, 'Hello world!']
end

Adelnor::Server.run app, 3000, thread_pool: 5
```