### PR TITLE
Add different strategies for concurrency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source 'https://rubygems.org'
 
 gem 'rack'
 gem 'rubocop', require: false
+gem 'async'

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@
 
 source 'https://rubygems.org'
 
+gem 'async'
 gem 'rack'
 gem 'rubocop', require: false
-gem 'async'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,17 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    async (2.6.4)
+      console (~> 1.10)
+      fiber-annotation
+      io-event (~> 1.1)
+      timers (~> 4.1)
+    console (1.23.2)
+      fiber-annotation
+      fiber-local
+    fiber-annotation (0.2.0)
+    fiber-local (1.0.0)
+    io-event (1.3.2)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
@@ -21,12 +32,15 @@ GEM
     rubocop-ast (1.18.0)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
+    timers (4.3.5)
     unicode-display_width (2.1.0)
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
+  async
   rack
   rubocop
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ $ make bundle.install
 $ make sample.server
 ```
 
-## Using Thread Pool
+## Handling concurrency
+
+Currently Adelnor allows to run the server using different concurrency strategies.
 
 ```ruby
 require './lib/adelnor/server'
@@ -66,7 +68,14 @@ app = -> (env) do
   [200, { 'Content-Type' => 'text/html' }, 'Hello world!']
 end
 
+# Threaded mode
 Adelnor::Server.run app, 3000, thread_pool: 5
+
+# Clusterd mode (forking)
+Adelnor::Server.run app, 3000, workers: 2
+
+# Async mode
+Adelnor::Server.run app, 3000, async: true
 ```
 
 Open `http://localhost:3000`

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ make sample.server
 
 ## Handling concurrency
 
-Currently Adelnor allows to run the server using different concurrency strategies.
+Currently Adelnor allows to run the server using different concurrency strategies, one at a time.
 
 ```ruby
 require './lib/adelnor/server'

--- a/adelnor.gemspec
+++ b/adelnor.gemspec
@@ -11,8 +11,8 @@ Gem::Specification.new do |spec|
   spec.homepage    = 'https://github.com/leandronsp/adelnor'
   spec.license     = 'MIT'
 
-  spec.add_runtime_dependency 'rack', '~> 2.2'
   spec.add_runtime_dependency 'async', '~> 2.6'
+  spec.add_runtime_dependency 'rack', '~> 2.2'
 
   spec.required_ruby_version = '~> 3.0'
 end

--- a/adelnor.gemspec
+++ b/adelnor.gemspec
@@ -11,7 +11,8 @@ Gem::Specification.new do |spec|
   spec.homepage    = 'https://github.com/leandronsp/adelnor'
   spec.license     = 'MIT'
 
-  spec.add_runtime_dependency 'rack'
+  spec.add_runtime_dependency 'rack', '~> 2.2'
+  spec.add_runtime_dependency 'async', '~> 2.6'
 
   spec.required_ruby_version = '~> 3.0'
 end

--- a/lib/adelnor/async_server.rb
+++ b/lib/adelnor/async_server.rb
@@ -1,31 +1,29 @@
 # frozen_string_literal: true
 
 require_relative './base_server'
+require 'async'
+require 'async/scheduler'
 
 module Adelnor
-  class ClusteredServer < BaseServer
+  class AsyncServer < BaseServer
     def initialize(rack_app, port, options = {})
       super(rack_app, port, options)
 
-      @workers = options[:workers]
+      scheduler = Async::Scheduler.new
+      Fiber.set_scheduler(scheduler)
     end
 
     def run
-      @workers.times do 
-        fork do
-          pid = Process.pid
-          puts "[#{pid}] Worker started"
+      Async do |task|
+        loop do
+          client, = @socket.accept
 
-          loop do
-            client, = @socket.accept
-
+          task.async do
             handle(client)
             client.close
           end
         end
       end
-
-      Process.waitall
     end
   end
 end

--- a/lib/adelnor/base_server.rb
+++ b/lib/adelnor/base_server.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'socket'
+require 'rack'
+require 'stringio'
+
+require_relative './request'
+require_relative './response'
+
+module Adelnor
+  class BaseServer
+    def initialize(rack_app, port, options = {})
+      @rack_app = rack_app
+      @port     = port
+      @options  = options
+      @socket   = Socket.new(:INET, :STREAM)
+      addr      = Socket.sockaddr_in(@port, '0.0.0.0')
+
+      @socket.bind(addr)
+      @socket.listen(2)
+
+      puts welcome_message
+    end
+
+    def self.run(*args)
+      new(*args).run
+    end
+
+    def rack_data(request)
+      {
+        'REQUEST_METHOD' => request.request_method,
+        'PATH_INFO' => request.path_info,
+        'QUERY_STRING' => request.query_string,
+        'SERVER_PORT' => @port,
+        'SERVER_NAME' => request.headers['Host'],
+        'CONTENT_LENGTH' => request.content_length,
+        'HTTP_COOKIE' => request.headers['Cookie'],
+        'rack.input' => StringIO.new(request.body)
+      }.merge(request.headers)
+    end
+
+    def run
+      loop do
+        client, = @socket.accept
+
+        handle(client)
+        client.close
+      end
+    end
+
+    def handle(client)
+      read_request_message(client)
+        .then { |message|  Request.build(message) }
+        .tap  { |request|  request.parse_body!(client) }
+        .then { |request|  rack_data(request) }
+        .then { |data|     @rack_app.call(data) }
+        .then { |result|   Response.build(*result) }
+        .then { |response| client.puts(response) }
+    end
+
+    def read_request_message(client)
+      message = ''
+
+      if (line = client.gets)
+        message += line
+      end
+
+      puts "\n[#{Time.now}] #{message}"
+
+      while (line = client.gets)
+        break if line == "\r\n"
+
+        message += line
+      end
+
+      message
+    end
+
+    def welcome_message
+      thread_pool_message = "Running with thread pool of #{@options[:thread_pool]} threads" if @options[:thread_pool]
+
+      <<~WELCOME
+        |\---/|
+        | o_o |
+         \_^_/
+
+        adelnor HTTP server
+
+        ------------------------------------------------
+
+        Adelnor is running at http://0.0.0.0:#{@port}
+        Listening to HTTP connections
+
+        #{thread_pool_message}
+      WELCOME
+    end
+  end
+end

--- a/lib/adelnor/clustered_server.rb
+++ b/lib/adelnor/clustered_server.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative './base_server'
+
+module Adelnor
+  class ClusteredServer < BaseServer
+    def initialize(rack_app, port, options = {})
+      super(rack_app, port, options)
+
+      @cluster_size = options[:cluster]
+    end
+
+    def run
+      @cluster_size.times do 
+        fork do
+          pid = Process.pid
+          puts "[#{pid}] Worker started"
+
+          loop do
+            client, = @socket.accept
+
+            handle(client)
+            client.close
+          end
+        end
+      end
+
+      Process.waitall
+    end
+  end
+end

--- a/lib/adelnor/clustered_server.rb
+++ b/lib/adelnor/clustered_server.rb
@@ -11,21 +11,23 @@ module Adelnor
     end
 
     def run
-      @workers.times do 
-        fork do
-          pid = Process.pid
-          puts "[#{pid}] Worker started"
-
-          loop do
-            client, = @socket.accept
-
-            handle(client)
-            client.close
-          end
-        end
+      @workers.times do
+        fork { handle_worker }
       end
 
       Process.waitall
+    end
+
+    def handle_worker
+      pid = Process.pid
+      puts "[#{pid}] Worker started"
+
+      loop do
+        client, = @socket.accept
+
+        handle(client)
+        client.close
+      end
     end
   end
 end

--- a/lib/adelnor/ractor_server.rb
+++ b/lib/adelnor/ractor_server.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require_relative './base_server'
+
+module Adelnor
+  class RactorServer < BaseServer
+    def initialize(rack_app, port, options = {})
+      @ractors = options[:ractors]
+
+      @rack_app = rack_app
+      @port     = port
+      @options  = options
+
+      @queue = Ractor.new do
+        loop do
+          Ractor.yield(Ractor.receive, move: true)
+        end
+      end
+
+      @listener = Ractor.new(@queue, @port) do |queue, port|
+        socket   = Socket.new(:INET, :STREAM)
+        addr      = Socket.sockaddr_in(port, '0.0.0.0')
+
+        socket.bind(addr)
+        socket.listen(2)
+
+        loop do
+          client, = socket.accept
+
+          queue.send(client, move: true)
+        end
+      end
+
+      puts welcome_message
+    end
+
+    def run
+      ractors = @ractors.times.map do 
+        Ractor.new(@queue, @rack_app, @port) do |queue, rack_app, port|
+          rid = Ractor.current.object_id
+          puts "[#{rid}] Ractor started"
+
+          loop do
+            client = queue.take
+            message = ''
+
+            if (line = client.gets)
+              message += line
+            end
+
+            puts "\n[#{Time.now}] #{message}"
+
+            while (line = client.gets)
+              break if line == "\r\n"
+
+              message += line
+            end
+
+            rack_data = -> (request) do
+              { 
+                'REQUEST_METHOD' => request.request_method,
+                'PATH_INFO' => request.path_info,
+                'QUERY_STRING' => request.query_string,
+                'SERVER_PORT' => port,
+                'SERVER_NAME' => request.headers['Host'],
+                'CONTENT_LENGTH' => request.content_length,
+                'HTTP_COOKIE' => request.headers['Cookie'],
+                'rack.input' => StringIO.new(request.body)
+              }
+            end
+
+            Request.build(message)
+              .tap  { |request|  request.parse_body!(client) }
+              .then { |request|  rack_data.call(request).merge(request.headers) }
+              .then { |data|     rack_app.call(data) }
+              .then { |result|   Response.build(*result) }
+              .then { |response| client.puts(response) }
+
+            client.close
+          end
+        end
+      end
+
+      loop do
+        Ractor.select(@listener, *ractors)
+      end
+    end
+  end
+end

--- a/lib/adelnor/server.rb
+++ b/lib/adelnor/server.rb
@@ -2,6 +2,7 @@
 
 require_relative './base_server'
 require_relative './threaded_server'
+require_relative './clustered_server'
 
 module Adelnor
   class Server
@@ -16,7 +17,14 @@ module Adelnor
     end
 
     def run
-      handler_klass = @options[:thread_pool] ? ThreadedServer : BaseServer
+      handler_klass = if @options[:thread_pool] 
+        ThreadedServer 
+      elsif @options[:cluster]
+        ClusteredServer
+      else
+        BaseServer
+      end
+
       handler_klass.run(@rack_app, @port, @options)
     end
   end

--- a/lib/adelnor/server.rb
+++ b/lib/adelnor/server.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-require 'socket'
-require 'rack'
-require 'stringio'
-
-require_relative './request'
-require_relative './response'
+require_relative './base_server'
+require_relative './threaded_server'
 
 module Adelnor
   class Server
@@ -13,117 +9,15 @@ module Adelnor
       @rack_app = rack_app
       @port     = port
       @options  = options
-      @socket   = Socket.new(:INET, :STREAM)
-      addr      = Socket.sockaddr_in(@port, '0.0.0.0')
-
-      @socket.bind(addr)
-      @socket.listen(2)
-
-      @thread_queue = Queue.new if @options[:thread_pool]
-      puts welcome_message
     end
 
     def self.run(*args)
       new(*args).run
     end
 
-    def rack_data(request)
-      {
-        'REQUEST_METHOD' => request.request_method,
-        'PATH_INFO' => request.path_info,
-        'QUERY_STRING' => request.query_string,
-        'SERVER_PORT' => @port,
-        'SERVER_NAME' => request.headers['Host'],
-        'CONTENT_LENGTH' => request.content_length,
-        'HTTP_COOKIE' => request.headers['Cookie'],
-        'rack.input' => StringIO.new(request.body)
-      }.merge(request.headers)
-    end
-
     def run
-      if (pool_size = @options[:thread_pool])
-        return run_with_thread_pool(pool_size)
-      end
-
-      loop do
-        client, = @socket.accept
-
-        handle(client)
-        client.close
-      end
-    end
-
-    def run_with_thread_pool(pool_size)
-      pool_size.times do
-        handle_request_in_thread
-      end
-
-      loop do
-        client, = @socket.accept
-
-        @thread_queue.push(client)
-      end
-    end
-
-    def handle_request_in_thread
-      Thread.new do
-        tid = Thread.current.object_id
-
-        puts "[#{tid}] Thread started"
-        loop do
-          client = @thread_queue.pop
-
-          handle(client)
-          client.close
-        end
-      end
-    end
-
-    def handle(client)
-      read_request_message(client)
-        .then { |message|  Request.build(message) }
-        .tap  { |request|  request.parse_body!(client) }
-        .then { |request|  rack_data(request) }
-        .then { |data|     @rack_app.call(data) }
-        .then { |result|   Response.build(*result) }
-        .then { |response| client.puts(response) }
-    end
-
-    def read_request_message(client)
-      message = ''
-
-      if (line = client.gets)
-        message += line
-      end
-
-      puts "\n[#{Time.now}] #{message}"
-
-      while (line = client.gets)
-        break if line == "\r\n"
-
-        message += line
-      end
-
-      message
-    end
-
-    def welcome_message
-      thread_pool_message = "Running with thread pool of #{@options[:thread_pool]} threads" if @options[:thread_pool]
-
-      <<~WELCOME
-        |\---/|
-        | o_o |
-         \_^_/
-
-        adelnor HTTP server
-
-        ------------------------------------------------
-
-        Adelnor is running at http://0.0.0.0:#{@port}
-        Listening to HTTP connections
-
-        #{thread_pool_message}
-      WELCOME
+      handler_klass = @options[:thread_pool] ? ThreadedServer : BaseServer
+      handler_klass.run(@rack_app, @port, @options)
     end
   end
 end

--- a/lib/adelnor/server.rb
+++ b/lib/adelnor/server.rb
@@ -3,6 +3,8 @@
 require_relative './base_server'
 require_relative './threaded_server'
 require_relative './clustered_server'
+require_relative './ractor_server'
+require_relative './async_server'
 
 module Adelnor
   class Server
@@ -19,8 +21,12 @@ module Adelnor
     def run
       handler_klass = if @options[:thread_pool] 
         ThreadedServer 
-      elsif @options[:cluster]
+      elsif @options[:workers]
         ClusteredServer
+      #elsif @options[:ractors]
+      #  RactorServer
+      elsif @options[:async]
+        AsyncServer
       else
         BaseServer
       end

--- a/lib/adelnor/server.rb
+++ b/lib/adelnor/server.rb
@@ -19,17 +19,17 @@ module Adelnor
     end
 
     def run
-      handler_klass = if @options[:thread_pool] 
-        ThreadedServer 
-      elsif @options[:workers]
-        ClusteredServer
-      #elsif @options[:ractors]
-      #  RactorServer
-      elsif @options[:async]
-        AsyncServer
-      else
-        BaseServer
-      end
+      handler_klass = if @options[:thread_pool]
+                        ThreadedServer
+                      elsif @options[:workers]
+                        ClusteredServer
+                      # elsif @options[:ractors]
+                      #  RactorServer
+                      elsif @options[:async]
+                        AsyncServer
+                      else
+                        BaseServer
+                      end
 
       handler_klass.run(@rack_app, @port, @options)
     end

--- a/lib/adelnor/threaded_server.rb
+++ b/lib/adelnor/threaded_server.rb
@@ -13,23 +13,25 @@ module Adelnor
 
     def run
       @pool_size.times do
-        Thread.new do
-          tid = Thread.current.object_id
-
-          puts "[#{tid}] Thread started"
-          loop do
-            client = @thread_queue.pop
-
-            handle(client)
-            client.close
-          end
-        end
+        Thread.new { handle_thread }
       end
 
       loop do
         client, = @socket.accept
 
         @thread_queue.push(client)
+      end
+    end
+
+    def handle_thread
+      tid = Thread.current.object_id
+
+      puts "[#{tid}] Thread started"
+      loop do
+        client = @thread_queue.pop
+
+        handle(client)
+        client.close
       end
     end
   end

--- a/lib/adelnor/threaded_server.rb
+++ b/lib/adelnor/threaded_server.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative './base_server'
+
+module Adelnor
+  class ThreadedServer < BaseServer
+    def initialize(rack_app, port, options = {})
+      super(rack_app, port, options)
+
+      @thread_queue = Queue.new
+      @pool_size = options[:thread_pool]
+    end
+
+    def run
+      @pool_size.times do
+        Thread.new do
+          tid = Thread.current.object_id
+
+          puts "[#{tid}] Thread started"
+          loop do
+            client = @thread_queue.pop
+
+            handle(client)
+            client.close
+          end
+        end
+      end
+
+      loop do
+        client, = @socket.accept
+
+        @thread_queue.push(client)
+      end
+    end
+  end
+end

--- a/sample-app/run
+++ b/sample-app/run
@@ -8,4 +8,7 @@ app = -> (env) do
   [200, { 'Content-Type' => 'text/html' }, 'Hello world!']
 end
 
-Adelnor::Server.run app, 3000, cluster: 5
+#Adelnor::Server.run app, 3000, thread_pool: 5
+#Adelnor::Server.run app, 3000, workers: 5
+#Adelnor::Server.run app, 3000, ractors: 5
+Adelnor::Server.run app, 3000, async: true

--- a/sample-app/run
+++ b/sample-app/run
@@ -8,4 +8,4 @@ app = -> (env) do
   [200, { 'Content-Type' => 'text/html' }, 'Hello world!']
 end
 
-Adelnor::Server.run app, 3000, thread_pool: 5
+Adelnor::Server.run app, 3000, cluster: 5


### PR DESCRIPTION
This PR adds the ability to handle different concurrency strategies. At this moment, Adelnor only support one strategy at a time, but in the future we plan to combine different strategies, i.e forking x threaded, forking x async etc

The current strategy implementations are:

* Threaded
* Clustered (workers)
* Ractors (in progress)
* Async (non-blocking I/O)